### PR TITLE
Update extra-data path

### DIFF
--- a/docs/part-3-serve-and-deploy-the-model/chapter-12-serve-the-model-locally-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy-the-model/chapter-12-serve-the-model-locally-with-bentoml.md
@@ -172,7 +172,7 @@ Here are some example you can use.
 Download the following image of the moon on your computer.
 
 <figure markdown>
-  ![Moon](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/Moon/Moon_145.jpg)
+  ![Moon](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/Moon_145.jpg)
 </figure>
 
 Upload it to the `/predict` endpoint and check the prediction.
@@ -203,7 +203,7 @@ The output should be similar to this:
 Download the following image of Makemake on your computer.
 
 <figure markdown>
-  ![Makemake](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/MakeMake/Makemake_146.jpg)
+  ![Makemake](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/Makemake_146.jpg)
 </figure>
 
 Upload it to the `/predict` endpoint and check the prediction.
@@ -234,7 +234,7 @@ The output should be similar to this:
 Download the following image of Neptune on your computer.
 
 <figure markdown>
-  ![Neptune](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/Neptune/Neptune_146.jpg)
+  ![Neptune](https://raw.githubusercontent.com/swiss-ai-center/a-guide-to-mlops/extra-data/extra_data/Neptune_146.jpg)
 </figure>
 
 Upload it to the `/predict` endpoint and check the prediction.


### PR DESCRIPTION
Currently the `extra-data` branch contains subfolder for each planet/moon, however, this conflicts when importing the images to label studio as we can only select images.

The change is to extract the images from the subfolder of `extra-data`.

After this merge, a push will be made to `extra-data` with the new file structure.

**How does this affect the guide?**

It does not, as `extra-data` is used to test the inference. The image files already contain the classification name (ex: Earth_146.png).

In addition to this, it makes more sense to reuse this data for labelling, with the added benefit of images "not being classified" (even though as mentioned above, the class is still in the filename).