### PR TITLE
docs(label-studio): document macOS upload limit

### DIFF
--- a/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
@@ -189,6 +189,15 @@ git commit -m "Add Label Studio"
 
 You can now start Label Studio with the following command:
 
+!!! warning "macOS: raise the open-file limit"
+
+    Importing 1,000 images can exceed macOS's open-file limit. Raise it in the same
+    terminal before starting Label Studio:
+
+    ```sh title="Execute the following command(s) in a terminal"
+    ulimit -n 4096
+    ```
+
 ```sh title="Execute the following command(s) in a terminal"
 # Start Label Studio
 DATA_UPLOAD_MAX_NUMBER_FILES=1000 label-studio
@@ -200,23 +209,6 @@ DATA_UPLOAD_MAX_NUMBER_FILES=1000 label-studio
     `extra-data/extra` images at once. The default limit (100 files) is lower than
     the number of images in this chapter, which would force you to upload them in
     multiple batches.
-
-!!! warning "macOS: raise the open-file limit"
-
-    macOS shells typically allow a process to open only 256 files at once. Label
-    Studio opens a temporary file for every uploaded image, so importing all 1,000
-    images can fail with `[Errno 24] Too many open files` even after setting
-    `DATA_UPLOAD_MAX_NUMBER_FILES`.
-
-    Raise the soft limit in the same terminal before starting Label Studio:
-
-    ```sh title="Execute the following command(s) in a terminal"
-    ulimit -n 4096
-    DATA_UPLOAD_MAX_NUMBER_FILES=1000 label-studio
-    ```
-
-    The higher limit applies only to the current shell and the processes started
-    from it.
 
 Label Studio will start on <http://localhost:8080>. Open the URL in your browser
 and sign up for an account.

--- a/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md
@@ -201,6 +201,23 @@ DATA_UPLOAD_MAX_NUMBER_FILES=1000 label-studio
     the number of images in this chapter, which would force you to upload them in
     multiple batches.
 
+!!! warning "macOS: raise the open-file limit"
+
+    macOS shells typically allow a process to open only 256 files at once. Label
+    Studio opens a temporary file for every uploaded image, so importing all 1,000
+    images can fail with `[Errno 24] Too many open files` even after setting
+    `DATA_UPLOAD_MAX_NUMBER_FILES`.
+
+    Raise the soft limit in the same terminal before starting Label Studio:
+
+    ```sh title="Execute the following command(s) in a terminal"
+    ulimit -n 4096
+    DATA_UPLOAD_MAX_NUMBER_FILES=1000 label-studio
+    ```
+
+    The higher limit applies only to the current shell and the processes started
+    from it.
+
 Label Studio will start on <http://localhost:8080>. Open the URL in your browser
 and sign up for an account.
 


### PR DESCRIPTION
## Summary

- explain the macOS soft open-file limit that can block the 1,000-image Label Studio import
- provide the tested `ulimit -n 4096` command
- clarify that the raised limit is scoped to the current shell and its child processes

## Reproduction

On stock macOS, `ulimit -n` reported 256. Importing all 1,000 images into Label Studio 1.23.0 failed with HTTP 500 and `[Errno 24] Too many open files` while Django created temporary upload files.

After starting the same Label Studio instance from a shell with `ulimit -n 4096`, one multipart import completed with HTTP 201, returned `task_count: 1000`, and the project API independently reported 1,000 tasks.

## Validation

- `mdwrap --check docs/part-5-label-data-and-retrain/chapter-51-set-up-label-studio.md`
- `zensical build --clean`