### PR TITLE
Simplify the rollback procedure and wording in chapter 4.5

### DIFF
--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -179,7 +179,7 @@ git revert --no-commit $PREVIOUS_SHA..
 git commit -m "Rollback to $PREVIOUS_SHA"
 
 # Push the rollback to trigger the CI/CD pipeline
-git push origin main
+git push
 ```
 
 After the push, the CI/CD pipeline will build and deploy the rolled-back version

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -26,7 +26,7 @@ In this chapter, you will learn how to:
 1. Open and read the drift-alert issue created by the monitoring workflow
 2. Decide whether to tune thresholds, roll back, or label new data and retrain
 3. Adjust drift thresholds quickly in `src/monitor.py`
-4. Roll back the Kubernetes deployment and restore the canonical source of truth
+4. Roll back to the last known-good version with Git and DVC
 5. Verify the chosen action and close the issue
 
 The following diagram illustrates the decision flow at the end of this chapter:
@@ -113,15 +113,10 @@ thresholds and only open a new issue if drift still exceeds them.
 
 ### Option 2: Roll back the deployment
 
-If the deployed model is clearly worse than the previous version, roll back.
-There are two rollback paths:
-
-* **Fast rollback with Kubernetes** — revert the running deployment immediately.
-  Use this first to stop the incident, but remember that it does not change Git or
-  DVC.
-* **Canonical rollback with Git and DVC** — restore the exact code, model
-  artifact, and data that produced the previous version on `main`. Use this to
-  make the source of truth consistent and let the CI/CD pipeline redeploy cleanly.
+If the deployed model is clearly worse than the previous version, roll back to
+the last known-good version. Every commit to `main` produces a deployable image
+and the DVC pointer files track the model artifact and data, so reverting `main`
+and letting the CI/CD pipeline redeploy is all it takes.
 
 #### Find the previous known-good version
 
@@ -167,46 +162,11 @@ Set the rollback target once so the following commands can reuse it:
 export PREVIOUS_SHA=a1b2c3d4e5f6789012345678901234567890abcd
 ```
 
-#### Fast rollback with Kubernetes
+#### Roll back with Git and DVC
 
-If the previous pod revision is still available in Kubernetes,
-`kubectl rollout undo` is the fastest operational shortcut. It reverts the
-deployment to the previous ReplicaSet, which usually points to the image just
-before the last update.
-
-```sh title="Execute the following command(s) in a terminal"
-# Roll back the deployment one revision
-kubectl rollout undo deployment/celestial-bodies-classifier-deployment
-
-# Verify the rollback
-kubectl rollout status deployment/celestial-bodies-classifier-deployment
-```
-
-Check the rollout history to see which revision is active:
-
-```sh title="Execute the following command(s) in a terminal"
-kubectl rollout history deployment/celestial-bodies-classifier-deployment
-```
-
-This is the fastest way to recover, but it does not change Git or DVC. Use it
-for immediate incident response, then follow with the Git/DVC rollback below to
-keep the source of truth consistent.
-
-If the previous ReplicaSet is no longer available, you can still redeploy a
-specific image from the registry with `kubectl set image`:
-
-```sh title="Execute the following command(s) in a terminal"
-kubectl set image deployment/celestial-bodies-classifier-deployment \
-  celestial-bodies-classifier=$GCP_CONTAINER_REGISTRY_HOST/celestial-bodies-classifier:$PREVIOUS_SHA
-
-kubectl rollout status deployment/celestial-bodies-classifier-deployment
-```
-
-#### Canonical rollback with Git and DVC
-
-The canonical rollback restores the exact code, model artifact, and data that
-produced the previous version. It is slower than the Kubernetes rollback, but it
-keeps the repository consistent and lets the CI/CD pipeline redeploy cleanly.
+The rollback restores the exact code, model artifact, and data that produced the
+previous version on `main`, so the source of truth stays consistent and the
+CI/CD pipeline redeploys cleanly.
 
 Create a new commit on `main` that reverts the bad commits since the last
 known-good version, using the same commit SHA as the previous step. This
@@ -223,6 +183,23 @@ git push origin main
 
 After the push, the CI/CD pipeline will build and deploy the rolled-back version
 automatically, bringing the container registry back into sync with Git and DVC.
+
+!!! info "Fast rollback for live incidents"
+
+    If production is down and you must restore service immediately,
+    `kubectl rollout undo` reverts the deployment to the previous ReplicaSet:
+
+    ```sh title="Execute the following command(s) in a terminal"
+    # Roll back the deployment one revision
+    kubectl rollout undo deployment/celestial-bodies-classifier-deployment
+
+    # Verify the rollback
+    kubectl rollout status deployment/celestial-bodies-classifier-deployment
+    ```
+
+    This does not change Git or DVC, and the previous ReplicaSet is not necessarily
+    the known-good version you picked. Use it only to stop an incident, then follow
+    with the Git/DVC rollback above to keep the source of truth consistent.
 
 After the rollback succeeds, close the drift-alert issue from the GitHub
 interface and add a comment that records the action taken, for example "Rolled
@@ -300,8 +277,7 @@ In this chapter, you have successfully:
 2. Chose between tuning thresholds, rolling back, or labeling new data and
    retraining
 3. Adjusted drift thresholds in `src/monitor.py`
-4. Rolled back the Kubernetes deployment and restored the canonical source of
-   truth with Git and DVC
+4. Rolled back to the last known-good version with Git and DVC
 5. Verified the chosen action and closed the issue
 
 You fixed some of the previous issues:
@@ -321,11 +297,11 @@ All the items of the MLOps process for this part are now addressed.
     - **Rollback is only possible because every artifact is versioned**: Git
       tracks the code, DVC tracks the model and data, and the container registry
       tracks every deployable image.
-    - **Kubernetes rollout undo is the fastest operational shortcut**: use it
-      first to stop an incident, then follow with the canonical Git/DVC rollback to
-      keep the source of truth consistent.
     - **The Git/DVC rollback is the canonical recovery**: it restores the source
       of truth and lets the CI/CD pipeline redeploy the old version cleanly.
+    - **Kubernetes rollout undo is an incident-response shortcut**: it restores
+      service immediately but does not change Git or DVC, so it does not replace the
+      Git/DVC rollback.
     - **Real new distributions need retraining, not rollback**: Part 5 covers
       the labeling workflow.
     - **Close the issue when the decision is executed**: the alerting script

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -35,10 +35,8 @@ The following diagram illustrates the decision flow at the end of this chapter:
 flowchart TB
     issue[Drift-alert issue] -->|review| decision{Decision}
     decision -->|false positive| tune[Adjust thresholds]
-    decision -->|model degraded| rollback[Roll back with Git and DVC]
-    rollback -->|revert| git_rollback[Revert commits on main]
-    git_rollback -->|dvc pull| old_model[Previous model artifact]
-    old_model -->|CI/CD| redeploy[Redeploy via pipeline]
+    decision -->|model degraded| rollback[Revert commits on main]
+    rollback -->|CI/CD| redeploy[Redeploy via pipeline]
     decision -->|new distribution| label[Label new data]
     label --> retrain[Retrain with DVC]
     retrain --> new_reference[Rebuild reference dataset]
@@ -47,8 +45,6 @@ flowchart TB
     style decision opacity:0.4,color:#7f7f7f80
     style tune opacity:0.4,color:#7f7f7f80
     style rollback opacity:0.4,color:#7f7f7f80
-    style git_rollback opacity:0.4,color:#7f7f7f80
-    style old_model opacity:0.4,color:#7f7f7f80
     style redeploy opacity:0.4,color:#7f7f7f80
     style label opacity:0.4,color:#7f7f7f80
     style retrain opacity:0.4,color:#7f7f7f80

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -169,7 +169,8 @@ previous version on `main`, so the source of truth stays consistent and the
 CI/CD pipeline redeploys cleanly.
 
 Create a new commit on `main` that reverts the bad commits since the last
-known-good version, using the same commit SHA as the previous step. This
+known-good version, using the same commit SHA as the previous step.
+`--no-commit` reverts them all at once, into a single rollback commit. This
 preserves history — the bad deployment stays visible in the Git log, which keeps
 the deployed state traceable. The revert also restores the DVC pointer files, so
 the pipeline pulls the previous model artifact and data:
@@ -177,29 +178,16 @@ the pipeline pulls the previous model artifact and data:
 ```sh title="Execute the following command(s) in a terminal"
 # Revert the commits since the last known-good version
 git revert --no-commit $PREVIOUS_SHA..
+
+# Commit the rollback
 git commit -m "Rollback to $PREVIOUS_SHA"
+
+# Push the rollback to trigger the CI/CD pipeline
 git push origin main
 ```
 
 After the push, the CI/CD pipeline will build and deploy the rolled-back version
 automatically, bringing the container registry back into sync with Git and DVC.
-
-!!! info "Fast rollback for live incidents"
-
-    If production is down and you must restore service immediately,
-    `kubectl rollout undo` reverts the deployment to the previous ReplicaSet:
-
-    ```sh title="Execute the following command(s) in a terminal"
-    # Roll back the deployment one revision
-    kubectl rollout undo deployment/celestial-bodies-classifier-deployment
-
-    # Verify the rollback
-    kubectl rollout status deployment/celestial-bodies-classifier-deployment
-    ```
-
-    This does not change Git or DVC, and the previous ReplicaSet is not necessarily
-    the known-good version you picked. Use it only to stop an incident, then follow
-    with the Git/DVC rollback above to keep the source of truth consistent.
 
 After the rollback succeeds, close the drift-alert issue from the GitHub
 interface and add a comment that records the action taken, for example "Rolled
@@ -299,9 +287,6 @@ All the items of the MLOps process for this part are now addressed.
       tracks every deployable image.
     - **The Git/DVC rollback is the canonical recovery**: it restores the source
       of truth and lets the CI/CD pipeline redeploy the old version cleanly.
-    - **Kubernetes rollout undo is an incident-response shortcut**: it restores
-      service immediately but does not change Git or DVC, so it does not replace the
-      Git/DVC rollback.
     - **Real new distributions need retraining, not rollback**: Part 5 covers
       the labeling workflow.
     - **Close the issue when the decision is executed**: the alerting script
@@ -320,6 +305,5 @@ Continue to the conclusion to review what you have learned.
 
 ## Sources
 
-- [_Kubernetes Rollout Undo_ - kubernetes.io](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
 - [_Artifact Registry: List images_ - cloud.google.com](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images)
 - [_GitHub CLI: gh issue_](https://cli.github.com/manual/gh_issue)

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -56,8 +56,8 @@ flowchart TB
 ### Open the drift-alert issue
 
 The monitoring workflow labels the alert with `drift-alert`. Open your
-repository in the GitHub interface and go to the **Issues** tab — the open alert
-is at the top of the list.
+repository in the GitHub interface and go to the **Issues** tab. If other issues
+are open, filter by the `drift-alert` label to find the alert.
 
 Click the issue to open it. The issue body contains:
 
@@ -167,7 +167,7 @@ CI/CD pipeline redeploys cleanly.
 Create a new commit on `main` that reverts the bad commits since the last
 known-good version, using the same commit SHA as the previous step.
 `--no-commit` reverts them all at once, into a single rollback commit. This
-preserves history — the bad deployment stays visible in the Git log, which keeps
+preserves history: the bad deployment stays visible in the Git log, which keeps
 the deployed state traceable. The revert also restores the DVC pointer files, so
 the pipeline pulls the previous model artifact and data:
 

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -36,8 +36,8 @@ flowchart TB
     issue[Drift-alert issue] -->|review| decision{Decision}
     decision -->|false positive| tune[Adjust thresholds]
     decision -->|model degraded| rollback[Roll back with Git and DVC]
-    rollback -->|checkout| git_rollback[Checkout previous commit]
-    git_rollback -->|dvc checkout| old_model[Previous model artifact]
+    rollback -->|revert| git_rollback[Revert commits on main]
+    git_rollback -->|dvc pull| old_model[Previous model artifact]
     old_model -->|CI/CD| redeploy[Redeploy via pipeline]
     decision -->|new distribution| label[Label new data]
     label --> retrain[Retrain with DVC]
@@ -208,45 +208,21 @@ The canonical rollback restores the exact code, model artifact, and data that
 produced the previous version. It is slower than the Kubernetes rollback, but it
 keeps the repository consistent and lets the CI/CD pipeline redeploy cleanly.
 
-Using the same commit SHA as the previous step:
-
-```sh title="Execute the following command(s) in a terminal"
-# Checkout the previous known-good version
-git checkout $PREVIOUS_SHA
-
-# Restore the exact model artifact and data from DVC
-dvc checkout
-```
-
-At this point your workspace contains the old model and data. You now have two
-options to put that state back on `main`:
-
-**Option A: revert commit (safest)**
-
 Create a new commit on `main` that reverts the bad commits since the last
-known-good version. This preserves history and works well when the problematic
-change is contained in a small number of recent commits.
+known-good version, using the same commit SHA as the previous step. This
+preserves history — the bad deployment stays visible in the Git log, which keeps
+the deployed state traceable. The revert also restores the DVC pointer files, so
+the pipeline pulls the previous model artifact and data:
 
 ```sh title="Execute the following command(s) in a terminal"
-git checkout main
+# Revert the commits since the last known-good version
 git revert --no-commit $PREVIOUS_SHA..
 git commit -m "Rollback to $PREVIOUS_SHA"
 git push origin main
 ```
 
-**Option B: reset main to the known-good commit**
-
-Use this only if the bad deployment has not been pulled by other team members
-and you are comfortable rewriting public history.
-
-```sh title="Execute the following command(s) in a terminal"
-git checkout main
-git reset --hard $PREVIOUS_SHA
-git push --force-with-lease origin main
-```
-
 After the push, the CI/CD pipeline will build and deploy the rolled-back version
-automatically, bringing the container registry back into sync with Git.
+automatically, bringing the container registry back into sync with Git and DVC.
 
 After the rollback succeeds, close the drift-alert issue from the GitHub
 interface and add a comment that records the action taken, for example "Rolled
@@ -368,7 +344,6 @@ Continue to the conclusion to review what you have learned.
 
 ## Sources
 
-- [_DVC Checkout_ - dvc.org](https://dvc.org/doc/command-reference/checkout)
 - [_Kubernetes Rollout Undo_ - kubernetes.io](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
 - [_Artifact Registry: List images_ - cloud.google.com](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images)
 - [_GitHub CLI: gh issue_](https://cli.github.com/manual/gh_issue)

--- a/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
+++ b/docs/part-4-monitor-and-maintain/chapter-45-review-drift-alerts-and-decide-on-action.md
@@ -4,9 +4,8 @@
 
 Now that the drift alert system is in place, the monitoring workflow opens a
 GitHub issue whenever drift exceeds the thresholds defined in `src/monitor.py`.
-The issue records the drift score, links to the Evidently dashboard, and lists
-the next steps. It flags that something changed but the team still has to decide
-what to do about it.
+The issue records the drift score and links to the Evidently dashboard. It flags
+that something changed, but the team still has to decide what to do about it.
 
 This chapter shows how to review that issue and choose one of three actions:
 
@@ -37,7 +36,7 @@ flowchart TB
     issue[Drift-alert issue] -->|review| decision{Decision}
     decision -->|false positive| tune[Adjust thresholds]
     decision -->|model degraded| rollback[Roll back with Git and DVC]
-    rollback -->|checkout| git_rollback[Checkout previous Git tag]
+    rollback -->|checkout| git_rollback[Checkout previous commit]
     git_rollback -->|dvc checkout| old_model[Previous model artifact]
     old_model -->|CI/CD| redeploy[Redeploy via pipeline]
     decision -->|new distribution| label[Label new data]
@@ -60,9 +59,9 @@ flowchart TB
 
 ### Open the drift-alert issue
 
-The monitoring workflow labels every drift alert with `drift-alert`. Open your
-repository in the GitHub interface, go to the **Issues** tab, and filter by the
-`drift-alert` label to find the open alert.
+The monitoring workflow labels the alert with `drift-alert`. Open your
+repository in the GitHub interface and go to the **Issues** tab — the open alert
+is at the top of the list.
 
 Click the issue to open it. The issue body contains:
 
@@ -76,9 +75,9 @@ If this was a test alert or the drift has already been handled, click the
 
 ### Review the evidence
 
-The issue links to the Evidently dashboard and to `monitoring/report.json`. You
-already inspected both in the previous chapter, so use that review to decide
-which branch of the decision tree applies:
+The issue shows the drift scores extracted from `monitoring/report.json` and
+links to the Evidently dashboard. You already inspected both in the previous
+chapter, so use that review to decide which branch of the decision tree applies:
 
 * **Noise or expected variation**: tune the thresholds.
 * **Real degradation of the deployed model**: roll back.
@@ -159,14 +158,6 @@ You can also find the same SHA in Git:
 ```sh title="Execute the following command(s) in a terminal"
 # Show recent commits on main
 git log --oneline -10 main
-```
-
-If your team creates Git tags for releases, use those instead. A tag such as
-`model-v1.2.2` is easier to communicate than a commit SHA:
-
-```sh title="Execute the following command(s) in a terminal"
-# List release tags
-git tag --sort=-creatordate | head -10
 ```
 
 Set the rollback target once so the following commands can reuse it:
@@ -377,7 +368,6 @@ Continue to the conclusion to review what you have learned.
 
 ## Sources
 
-- [_Git Tags_ - git-scm.com](https://git-scm.com/book/en/v2/Git-Basics-Tagging)
 - [_DVC Checkout_ - dvc.org](https://dvc.org/doc/command-reference/checkout)
 - [_Kubernetes Rollout Undo_ - kubernetes.io](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-back-a-deployment)
 - [_Artifact Registry: List images_ - cloud.google.com](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images)


### PR DESCRIPTION
- **Simplify wording and remove Git tag aside in chapter 4.5**
- **Keep revert as the sole canonical rollback strategy in chapter 4.5**
- **Demote fast Kubernetes rollback to an info box in chapter 4.5**
- **Remove live-incident rollback info box and polish revert commands in chapter 4.5**
- **Simplify the rollback branch of the decision diagram in chapter 4.5**
