### PR TITLE
Fix typos and improve clarity across the guide

### DIFF
--- a/docs/clean-up.md
+++ b/docs/clean-up.md
@@ -214,8 +214,8 @@ Here is a checklist of all the resources and environments you created.
 - [ ] The cloud provider S3 bucket
 - [ ] The cloud provider credentials
 - [ ] The cloud provider project
-- [ ] The GitHub or GitLab Personal Access Tokens
-- [ ] The GitHub or GitLab repository
+- [ ] The GitHub Personal Access Tokens
+- [ ] The GitHub repository
 - [ ] The projects directories
     - [ ] The `mlops-guide-notebook` directory
     - [ ] The `mlops-guide` directory

--- a/docs/clean-up.md
+++ b/docs/clean-up.md
@@ -175,6 +175,16 @@ To delete the GitHub Personal Access Token you created:
 5. Click on the **Delete** button next to it.
 6. Follow the instructions to delete the token.
 
+### Clean up the BentoML model store
+
+BentoML stores the models you saved during the guide in its model store at
+`~/bentoml`. Delete it to free the disk space.
+
+```sh title="Execute the following command(s) in a terminal"
+# Delete the BentoML model store
+rm -rf ~/bentoml
+```
+
 ### Clean up your local environment
 
 In this section, you will delete the local environment you created for this
@@ -216,6 +226,7 @@ Here is a checklist of all the resources and environments you created.
 - [ ] The cloud provider project
 - [ ] The GitHub Personal Access Tokens
 - [ ] The GitHub repository
+- [ ] The BentoML model store
 - [ ] The projects directories
     - [ ] The `mlops-guide-notebook` directory
     - [ ] The `mlops-guide` directory

--- a/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
+++ b/docs/part-1-local-training-and-evaluation/chapter-13-initialize-git-and-dvc-for-local-training.md
@@ -310,9 +310,6 @@ which serves as the configuration directory for DVC.
     dvc config core.analytics false
     ```
 
-    For more information, see the
-    [DVC Analytics documentation](https://dvc.org/doc/user-guide/analytics).
-
 #### Update the .gitignore file and add the experiment data to DVC
 
 With DVC now set up, you can begin adding files to it.
@@ -513,3 +510,4 @@ Highly inspired by:
 
 - [_Get Started_ - dvc.org](https://dvc.org/doc/start)
 - [_Get Started: Data Versioning_ - dvc.org](https://dvc.org/doc/start/data-management)
+- [_Anonymized Usage Analytics_ - dvc.org](https://dvc.org/doc/user-guide/analytics)

--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -699,6 +699,14 @@ You fixed some of the previous issues:
       and imported in CI/CD pipelines, bridging the gap between local development and
       automated deployment.
 
+!!! question "Why BentoML instead of Docker directly?"
+
+    Docker packages any application but knows nothing about machine learning: the
+    serving API, model versioning, and the Dockerfile itself would all be
+    handwritten and maintained by you. BentoML provides them out of the box and
+    still produces a standard Docker image in the end, as you will see in the next
+    chapters. The two tools are complementary, not alternatives.
+
 ## State of the MLOps process
 
 - [x] Model can be saved and loaded with all required artifacts for future usage

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -490,6 +490,15 @@ You fixed some of the previous issues:
       configuration (how to route traffic) allows you to update the model version
       without changing how clients access it.
 
+!!! question "Why Kubernetes instead of a simple VM?"
+
+    For a single model, a virtual machine would indeed be simpler. But Kubernetes is
+    the de facto standard for running containers in production: the same declarative
+    configuration deploys on a Raspberry Pi cluster or a large cloud cluster, and is
+    understood by any engineer. It also provides self-healing, scaling, and load
+    balancing that you would script by hand on a VM, and the same manifests are
+    reused for CI/CD, training, and monitoring in the next chapters.
+
 ## State of the MLOps process
 
 - [x] Model can be saved and loaded with all required artifacts for future usage

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -317,11 +317,18 @@ spec:
     app: celestial-bodies-classifier
 ```
 
-* The `deployment.yaml` file describes the deployment of the model. It contains
-  the number of replicas, the image to use, and the labels to use.
+* The `deployment.yaml` file describes the **Deployment**: the desired state of
+  the pods running the model, such as the number of replicas and the container
+  image to use. Kubernetes keeps that many pods alive and replaces them if they
+  fail.
 
-* The `service.yaml` file describes the service of the model. It contains the
-  type of service, the ports to use, and the labels to use.
+* The `service.yaml` file describes the **Service**: a stable entry point that
+  routes traffic to the pods selected by their `app` label. Pods are ephemeral and
+  their IP addresses change, so the Service abstracts them away. With
+  `type: LoadBalancer`, the cloud provider also provisions an external load
+  balancer with a public IP address.
+
+In short, the deployment runs the workloads while the service exposes them.
 
 ### Deploy the containerised model on Kubernetes
 

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -401,6 +401,16 @@ service. You should be able to access the FastAPI documentation page at
 `http://<load balancer ingress ip>:80`. In this case, it is
 `http://34.65.255.92:80`.
 
+!!! warning "Plain HTTP only"
+
+    The load balancer exposes the service on port 80 over plain HTTP, without TLS.
+    Make sure to use `http://` and not `https://` when accessing it. Most browsers
+    default to HTTPS, which will fail to connect.
+
+    A production deployment should expose the service through a domain name,
+    terminate TLS with an Ingress and a certificate, and restrict access to the
+    endpoint.
+
 ### Check the changes
 
 Check the changes with Git to ensure that all the necessary files are tracked:

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -419,6 +419,12 @@ Create a new file called `runner.yaml` in the `kubernetes` directory with the
 following content. Replace also `<my_username>` and `<my_repository_name>` with
 your own GitHub username and repository name.
 
+??? warning "Using uppercase letters in your username or repository name? Read this!"
+
+    Docker requires the use of only lowercase characters for the image tag. If you
+    have uppercase letters in your username or repository name, simply convert them
+    to lowercase.
+
 ```txt title="kubernetes/runner.yaml" hl_lines="12"
 apiVersion: v1
 kind: Pod

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -446,6 +446,8 @@ spec:
             secretKeyRef:
               name: github-runner-pat
               key: token
+        - name: DVC_NO_ANALYTICS
+          value: "true"
       securityContext:
         runAsUser: 1000
       resources:
@@ -456,6 +458,12 @@ spec:
           cpu: "1"
           memory: "4Gi"
 ```
+
+!!! note "DVC analytics in CI/CD"
+
+    The `DVC_NO_ANALYTICS` environment variable disables DVC's anonymized usage
+    analytics. On every DVC command, analytics requests are sent over the network,
+    which can consume resources or stall the job in a restricted CI/CD environment.
 
 #### Add Kubeconfig secret
 
@@ -1017,3 +1025,4 @@ Highly inspired by:
 - [_Security for self-managed runners_ - GitLab docs](https://docs.gitlab.com/runner/security/)
 - [_Install kubectl and configure cluster access_ - cloud.google.com](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl)
 - [_Deploying to Google Kubernetes Engine_ - GitHub docs](https://docs.github.com/en/actions/use-cases-and-examples/deploying/deploying-to-google-kubernetes-engine)
+- [_Anonymized Usage Analytics_ - dvc.org](https://dvc.org/doc/user-guide/analytics)

--- a/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
+++ b/docs/part-3-serve-and-deploy/chapter-37-use-a-self-hosted-runner-for-the-cicd-pipeline.md
@@ -157,7 +157,7 @@ Replace `<my_repository_url>` with your own git repository URL, for example
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image label. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
@@ -280,7 +280,7 @@ username and repository name.
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
@@ -336,7 +336,7 @@ Push the docker image to the GitHub Container Registry:
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
@@ -421,7 +421,7 @@ your own GitHub username and repository name.
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -196,7 +196,7 @@ username and repository name.
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
@@ -287,7 +287,7 @@ your own GitHub username and repository name.
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -200,7 +200,7 @@ username and repository name.
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
-```txt title="kubernetes/runner.yaml" hl_lines="12 30-31"
+```txt title="kubernetes/runner.yaml" hl_lines="12 32-33"
 apiVersion: v1
 kind: Pod
 metadata:
@@ -221,6 +221,8 @@ spec:
             secretKeyRef:
               name: github-runner-pat
               key: token
+        - name: DVC_NO_ANALYTICS
+          value: "true"
       securityContext:
         runAsUser: 1000
       resources:
@@ -248,7 +250,7 @@ diff --git a/kubernetes/runner.yaml b/kubernetes/runner.yaml
 index 5a8dbb6..59b79f1 100644
 --- a/kubernetes/runner.yaml
 +++ b/kubernetes/runner.yaml
-@@ -25,3 +25,5 @@ spec:
+@@ -29,3 +29,5 @@ spec:
          requests:
            cpu: "1"
            memory: "4Gi"
@@ -319,6 +321,8 @@ spec:
             secretKeyRef:
               name: github-runner-pat
               key: token
+        - name: DVC_NO_ANALYTICS
+          value: "true"
       securityContext:
         runAsUser: 1000
       resources:

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -384,13 +384,13 @@ users:
       provideClusterInfo: true
 ```
 
-!!! info
+!!! warning "macOS: fix the gke-gcloud-auth-plugin path"
 
-    If using macOS, make sure the `users.user.exec.command` parameter is set to
-    `gke-gcloud-auth-plugin`. The kubeconfig file is generated locally and may point
-    to the Homebrew installation path. However, this configuration will be used in a
-    standard Linux environment when accessing the Kubernetes cluster from the CI/CD
-    pipeline.
+    The locally generated kubeconfig file may point to the Homebrew installation
+    path of `gke-gcloud-auth-plugin`. Make sure the `users.user.exec.command`
+    parameter is set to `gke-gcloud-auth-plugin`, as this configuration will be used
+    in a standard Linux environment when accessing the Kubernetes cluster from the
+    CI/CD pipeline.
 
 #### Add Kubernetes CI/CD secrets
 

--- a/docs/part-4-monitor-and-maintain/chapter-41-log-predictions-and-features-locally.md
+++ b/docs/part-4-monitor-and-maintain/chapter-41-log-predictions-and-features-locally.md
@@ -436,7 +436,7 @@ logs/
 dvc_plots
 
 # DVC will add new files after this line
-/mode
+/model
 ```
 
 ### Run the experiment

--- a/docs/part-4-monitor-and-maintain/chapter-42-detect-drift-locally-with-evidently-ai.md
+++ b/docs/part-4-monitor-and-maintain/chapter-42-detect-drift-locally-with-evidently-ai.md
@@ -907,6 +907,16 @@ obvious outliers, making them a realistic drift scenario.
 The folder also contains its own `.gitignore`, so its content is ignored
 automatically.
 
+#### Start from clean logs
+
+The test requests sent in the previous chapter are still in `logs/`. Remove them
+so the drift report only reflects the images sent in this chapter.
+
+```sh title="Execute the following command(s) in a terminal"
+# Remove previous monitoring logs
+rm -rf logs
+```
+
 #### Start the local service
 
 Start the BentoML service locally. It will serve the `/predict` endpoint and

--- a/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
+++ b/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
@@ -495,7 +495,7 @@ the GitHub Container Registry, replace `<my_username>` and
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 
@@ -552,7 +552,7 @@ Registry path and the bucket name:
 
 ??? warning "Using uppercase letters in your username or repository name? Read this!"
 
-    Docker requires the use of only lowercase characters for the image tag. If you
+    Docker requires the use of only lowercase characters for the image name. If you
     have uppercase letters in your username or repository name, simply convert them
     to lowercase.
 

--- a/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
+++ b/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
@@ -493,6 +493,12 @@ Build and publish the UI image to the GitHub Container Registry. Since we use
 the GitHub Container Registry, replace `<my_username>` and
 `<my_repository_name>` with your own GitHub username and repository name.
 
+??? warning "Using uppercase letters in your username or repository name? Read this!"
+
+    Docker requires the use of only lowercase characters for the image tag. If you
+    have uppercase letters in your username or repository name, simply convert them
+    to lowercase.
+
 ```sh title="Execute the following command(s) in a terminal"
 # Build the UI image
 docker build --platform=linux/amd64 -f docker/ui.Dockerfile --tag ghcr.io/<my_username>/<my_repository_name>/celestial-bodies-evidently-ui:latest .
@@ -543,6 +549,12 @@ spec:
 
 Replace the placeholders in the Kubernetes manifest with the GitHub Container
 Registry path and the bucket name:
+
+??? warning "Using uppercase letters in your username or repository name? Read this!"
+
+    Docker requires the use of only lowercase characters for the image tag. If you
+    have uppercase letters in your username or repository name, simply convert them
+    to lowercase.
 
 ```sh title="Execute the following command(s) in a terminal"
 export EVIDENTLY_UI_IMAGE=ghcr.io/<my_username>/<my_repository_name>/celestial-bodies-evidently-ui:latest

--- a/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
@@ -76,8 +76,8 @@ In the project view, you can see the progress of the labeling task.
 
 Note that you can also import additional data and export the labels.
 
-Currently, we have labeled one image but in the next chapter, we will learn how
-to use the model we trained earlier to label the images automatically.
+Currently, we have labeled a few images but in the next chapter, we will learn
+how to use the model we trained earlier to label all the images automatically.
 
 ## Summary
 

--- a/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
@@ -39,7 +39,7 @@ Make sure Label Studio is running at <http://localhost:8080>.
 Click on the **Label All Tasks** button to start labeling the images. The images
 will be displayed one by one in sequential order.
 
-### Label an image
+### Label a few images
 
 You will be presented with the image and the choices you defined earlier.
 
@@ -54,12 +54,13 @@ You will be presented with the image and the choices you defined earlier.
 1. Select the correct label for the image. In this case, the image is of the
    planet Earth.
 2. Click **Submit** to save the label.
-3. We will stop at the next displayed image for labeling.
+3. Repeat these steps for the next images to label a few of them, then stop.
+   Labeling five to ten images is enough.
 
 !!! warning
 
-    We will not be labeling more images, as we need to keep some unlabeled data for
-    the next chapter. You can go back to the project view by
+    Do not label all the images: we need to keep some unlabeled data for the next
+    chapter. You can go back to the project view by
     **clicking on your project name** on the top navigation bar.
 
 ### Track the progress

--- a/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
+++ b/docs/part-5-label-data-and-retrain/chapter-52-label-new-data-with-label-studio.md
@@ -52,7 +52,7 @@ You will be presented with the image and the choices you defined earlier.
 ![Label Studio Label Image](../assets/images/label-studio-label-image.png)
 
 1. Select the correct label for the image. In this case, the image is of the
-   planet Uranus.
+   planet Earth.
 2. Click **Submit** to save the label.
 3. We will stop at the next displayed image for labeling.
 

--- a/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
+++ b/docs/part-5-label-data-and-retrain/chapter-54-retrain-the-model-from-new-data-with-dvc.md
@@ -56,7 +56,7 @@ flowchart TB
 
 Make sure Label Studio is running at <http://localhost:8080>.
 
-1. In the project view, click on the **Export** button and select `JSON-MINI`.
+1. In the project view, click on the **Export** button and select `JSON-MIN`.
 
     ![Label Studio Export Annotations](../assets/images/label-studio-export-annotations.png)
 


### PR DESCRIPTION
- **Remove GitLab mentions from cleanup checklist**
- **Add BentoML model store to cleanup instructions**
- **Fix Label Studio export format name to JSON-MIN**
- **Fix labeled image count wording in Label Studio chapter**
- **Fix planet name in Label Studio labeling example**
- **Fix model typo in gitignore example**
- **Add clean logs step before drift detection experiment**
- **Add lowercase image tag warnings to remaining ghcr.io references**
- **Turn macOS kubeconfig note into titled warning**
- **Add plain HTTP warning for load balancer access**
- **Explain deployment vs service roles in Kubernetes chapter**
- **Disable DVC analytics on self-hosted runner pods**
- **Move DVC analytics link to chapter sources**
- **Add why BentoML over plain Docker note**
- **Add why Kubernetes over a simple VM note**
