### PR TITLE
Improve clarity of final workflow steps and 'why' admonitions

### DIFF
--- a/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
+++ b/docs/part-3-serve-and-deploy/chapter-31-save-and-load-the-model-with-bentoml.md
@@ -19,6 +19,14 @@ In this chapter, you will learn how to:
 3. Update and run the experiment to use BentoML to save and load the model to
    and from the model's store
 
+??? question "Why BentoML instead of Docker directly?"
+
+    Docker packages any application but knows nothing about machine learning: the
+    serving API, model versioning, and the Dockerfile itself would all be
+    handwritten and maintained by you. BentoML provides them out of the box and
+    still produces a standard Docker image in the end, as you will see in the next
+    chapters. The two tools are complementary, not alternatives.
+
 The following diagram illustrates the control flow of the experiment at the end
 of this chapter:
 
@@ -698,14 +706,6 @@ You fixed some of the previous issues:
       `.bentomodel` files allows them to be tracked by DVC, shared with team members,
       and imported in CI/CD pipelines, bridging the gap between local development and
       automated deployment.
-
-!!! question "Why BentoML instead of Docker directly?"
-
-    Docker packages any application but knows nothing about machine learning: the
-    serving API, model versioning, and the Dockerfile itself would all be
-    handwritten and maintained by you. BentoML provides them out of the box and
-    still produces a standard Docker image in the end, as you will see in the next
-    chapters. The two tools are complementary, not alternatives.
 
 ## State of the MLOps process
 

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -16,6 +16,15 @@ In this chapter, you will learn how to:
 4. Deploy the Docker image on Kubernetes
 5. Access the model
 
+??? question "Why Kubernetes instead of a simple VM?"
+
+    For a single model, a virtual machine would indeed be simpler. But Kubernetes is
+    the de facto standard for running containers in production: the same declarative
+    configuration deploys on a Raspberry Pi cluster or a large cloud cluster, and is
+    understood by any engineer. It also provides self-healing, scaling, and load
+    balancing that you would script by hand on a VM, and the same manifests are
+    reused for CI/CD, training, and monitoring in the next chapters.
+
 !!! danger
 
     The following steps will create resources on the cloud provider. These resources
@@ -489,15 +498,6 @@ You fixed some of the previous issues:
       deployment configuration (how many pods, which image) separate from service
       configuration (how to route traffic) allows you to update the model version
       without changing how clients access it.
-
-!!! question "Why Kubernetes instead of a simple VM?"
-
-    For a single model, a virtual machine would indeed be simpler. But Kubernetes is
-    the de facto standard for running containers in production: the same declarative
-    configuration deploys on a Raspberry Pi cluster or a large cloud cluster, and is
-    understood by any engineer. It also provides self-healing, scaling, and load
-    balancing that you would script by hand on a VM, and the same manifests are
-    reused for CI/CD, training, and monitoring in the next chapters.
 
 ## State of the MLOps process
 

--- a/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
+++ b/docs/part-3-serve-and-deploy/chapter-38-train-the-model-on-a-kubernetes-pod.md
@@ -794,51 +794,69 @@ Finally, try to update some parameters of your model to test the training on the
 specialized Kubernetes pod.
 
 Similarly to what you have done in
-[Chapter 2.5: Work efficiently and collaboratively with Git](../part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md),
-create an issue **Demonstrate model training on Kubernetes pod** and a new
-branch for the issue.
+[Chapter 2.5: Work efficiently and collaboratively with Git](../part-2-move-to-the-cloud/chapter-25-work-efficiently-and-collaboratively-with-git.md):
 
-On your machine, check out the new branch.
+- **Open an issue**: create a new issue named
+  _Demonstrate model training on Kubernetes pod_ by going to the **Issues**
+  section from the top header of your GitHub repository. Select **New issue** and
+  create the issue by selecting **Create**.
+- **Create a branch for the issue**: in the newly created issue, select
+  **Create a branch for this issue or link a pull request** from the right
+  sidebar. Create the branch by selecting **Create branch**. A new pop-up opens
+  with the name of the branch you want to check out.
+- **Check out the new branch** on your machine. Replace
+  `<the_name_of_the_new_branch>` with the name of the branch to check out:
 
-Update your experiment by editing for example the `params.yaml` file with the
-following parameters:
+    ```sh title="Execute the following command(s) in a terminal"
+    # Get the latest updates from the remote origin
+    git fetch origin
 
-```yaml title="params.yaml" hl_lines="11"
-prepare:
-  seed: 5241
-  split: 0.2
-  image_size: [32, 32]
-  grayscale: True
-  batch_size: 32
+    # Check out the new branch
+    git checkout <the_name_of_the_new_branch>
+    ```
 
-train:
-  seed: 5241
-  lr: 0.001
-  epochs: 20
-  conv_size: 64
-  dense_size: 128
-  output_classes: 10
-```
+- **Update the parameters of the experiment** by editing for example the
+  `params.yaml` file with the following parameters:
 
-You can now commit and push the above changes to trigger a change on the remote
-repository.
+    ```yaml title="params.yaml" hl_lines="11"
+    prepare:
+      seed: 5241
+      split: 0.2
+      image_size: [32, 32]
+      grayscale: True
+      batch_size: 32
 
-This time, **do not** execute `dvc repro` locally but let the cluster pod handle
-the job for you. Push the changes to the remote repository.
+    train:
+      seed: 5241
+      lr: 0.001
+      epochs: 20
+      conv_size: 64
+      dense_size: 128
+      output_classes: 10
+    ```
 
-```sh title="Execute the following command(s) in a terminal"
-# Add all the files
-git add .
+- **Commit and push the experiment changes** to trigger a change on the remote
+  repository.
 
-# Check the status
-git status
+    !!! warning
 
-# Commit the changes
-git commit -m "Make some changes to the model"
+        This time, **do not** execute `dvc repro` nor `dvc push` locally. Let the
+        specialized pod on the Kubernetes cluster handle the training and the push to
+        the remote storage for you.
 
-# Push the changes
-git push
-```
+    ```sh title="Execute the following command(s) in a terminal"
+    # Add all the files
+    git add .
+
+    # Check the status
+    git status
+
+    # Commit the changes
+    git commit -m "Make some changes to the model"
+
+    # Push the changes
+    git push
+    ```
 
 ### Check the results
 
@@ -848,9 +866,22 @@ Go back to your GitHub repository.
   **Actions** page. The `train-and-report` job will run on a pod created by the
   self-hosted runner on the Kubernetes cluster. It trains the model and DVC pushes
   the trained model to the remote bucket.
-* Merge the pull request, and switch back to the main branch and pull the latest
-  changes. The `publish-and-deploy` will run on the main runner. It retrieves the
-  model with DVC, containerizes then deploys the model artifact.
+* Merge the pull request. The `publish-and-deploy` will run on the main runner.
+  It retrieves the model with DVC, containerizes then deploys the model artifact.
+
+Once the merge is done, switch back to the main branch and pull the latest
+changes:
+
+```sh title="Execute the following command(s) in a terminal"
+# Get the latest updates from the remote origin
+git fetch origin
+
+# Check out the main branch
+git checkout main
+
+# Pull the changes made by the pull request
+git pull
+```
 
 On Google Cloud Console, you can see the pod that has been created on the
 [Kubernetes Engine Workloads](https://console.cloud.google.com/kubernetes/workload/)

--- a/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
+++ b/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
@@ -22,6 +22,14 @@ In this chapter, you will learn how to:
 5. Access the cloud-hosted dashboard and the drift reports
 6. Commit the changes to Git
 
+??? question "Why a sidecar?"
+
+    A sidecar is a helper container that runs alongside the main application
+    container in the same pod. It keeps the model service unchanged, moves network
+    I/O out of the inference path, and shares a local volume with the model
+    container. Fluent Bit also batches small records into larger objects, which is
+    cheaper and faster than per-request uploads.
+
 The following diagram illustrates the control flow at the end of this chapter:
 
 ```mermaid
@@ -167,14 +175,6 @@ To make those logs durable, you will add a Fluent Bit sidecar to the model pod.
 Fluent Bit tails the local log files, buffers them in memory and on disk, and
 uploads them to the storage bucket when a batch reaches a configured size or
 age.
-
-!!! question "Why a sidecar?"
-
-    A sidecar is a helper container that runs alongside the main application
-    container in the same pod. It keeps the model service unchanged, moves network
-    I/O out of the inference path, and shares a local volume with the model
-    container. Fluent Bit also batches small records into larger objects, which is
-    cheaper and faster than per-request uploads.
 
 #### Create the Fluent Bit configuration
 

--- a/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
+++ b/docs/part-4-monitor-and-maintain/chapter-43-deploy-and-access-the-monitoring-on-kubernetes.md
@@ -168,7 +168,7 @@ Fluent Bit tails the local log files, buffers them in memory and on disk, and
 uploads them to the storage bucket when a batch reaches a configured size or
 age.
 
-!!! note "Why a sidecar?"
+!!! question "Why a sidecar?"
 
     A sidecar is a helper container that runs alongside the main application
     container in the same pod. It keeps the model service unchanged, moves network


### PR DESCRIPTION
## Summary

- **Chapter 3.8** (Train the model on a Kubernetes pod): the _Try it out one final time_ section is now an explicit checklist with bold steps (**Open an issue**, **Create a branch for the issue**, **Check out the new branch**, **Update the parameters of the experiment**, **Commit and push the experiment changes**) and copy-pasteable command blocks, matching the style of chapter 2.5 without repeating it word for word. The note about not running `dvc repro`/`dvc push` locally is now a `!!! warning` admonition, and switching back to the main branch after the merge has its own command block.
- **Chapter 4.3** (Deploy and access the monitoring on Kubernetes): the _Why a sidecar?_ note uses a `question` admonition instead of `note` for consistency.
- **Chapters 3.1, 3.5 and 4.3**: the _Why BentoML instead of Docker directly?_, _Why Kubernetes instead of a simple VM?_ and _Why a sidecar?_ admonitions are moved from the end of the chapters (or inline) into the chapter introductions, rendered collapsed with `??? question` so they don't break the flow for already-convinced readers.

`mdwrap --check` passes on all modified files.