### PR TITLE
Add a machine setup page for WSL 2, Ubuntu and macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ dependencies are listed in `requirements.txt`.
 │   ├── index.md                  # Story landing page
 │   ├── syllabus.md               # Tutorial overview
 │   ├── tools.md                  # Tooling overview
+│   ├── setup.md                  # Machine setup (WSL 2 / Ubuntu / macOS)
 │   ├── cheatsheet.md             # Terminal/command reference
 │   ├── philosophy.md
 │   ├── concept.md

--- a/docs/conclusion.md
+++ b/docs/conclusion.md
@@ -51,7 +51,7 @@ You now have a reusable workflow you can apply to your own projects. The same
 patterns (version control, automated pipelines, monitored serving, and iterative
 retraining) scale from a single experiment to a team-wide MLOps practice.
 
-Explore the additional [resources](references.md) to go further, and reach out
+Explore the additional [references](references.md) to go further, and reach out
 on [GitHub](https://github.com/swiss-ai-center/a-guide-to-mlops) if you have
 questions. If you found this guide valuable, please consider starring the
 repository. Your support helps us improve it.

--- a/docs/part-1-local-training-and-evaluation/introduction.md
+++ b/docs/part-1-local-training-and-evaluation/introduction.md
@@ -19,6 +19,9 @@ might encounter issues. Please use the
 [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
 (WSL 2) for optimal results.
 
+See the [Setup](../setup.md) page for step-by-step instructions to prepare a WSL
+2 or Ubuntu environment.
+
 ## Requirements
 
 The following requirements are necessary to follow this part:

--- a/docs/part-1-local-training-and-evaluation/introduction.md
+++ b/docs/part-1-local-training-and-evaluation/introduction.md
@@ -14,13 +14,11 @@ Learn how to train a model locally and evaluate it using
 ## Environment
 
 This guide has been written with :simple-apple: macOS and :simple-linux: Linux
-operating systems in mind. If you use :fontawesome-brands-windows: Windows, you
-might encounter issues. Please use the
+operating systems in mind. If you use :fontawesome-brands-windows: Windows,
+please use the
 [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
-(WSL 2) for optimal results.
-
-See the [Setup](../setup.md) page for step-by-step instructions to prepare a WSL
-2, Ubuntu or macOS environment.
+(WSL 2) for optimal results. See the [Setup](../setup.md) page for step-by-step
+instructions to prepare your machine.
 
 ## Requirements
 

--- a/docs/part-1-local-training-and-evaluation/introduction.md
+++ b/docs/part-1-local-training-and-evaluation/introduction.md
@@ -20,7 +20,7 @@ might encounter issues. Please use the
 (WSL 2) for optimal results.
 
 See the [Setup](../setup.md) page for step-by-step instructions to prepare a WSL
-2 or Ubuntu environment.
+2, Ubuntu or macOS environment.
 
 ## Requirements
 

--- a/docs/part-2-move-to-the-cloud/introduction.md
+++ b/docs/part-2-move-to-the-cloud/introduction.md
@@ -12,14 +12,6 @@ Learn how to collaborate online using [:simple-git: Git](../tools.md), enable
 seamless integration with a CI/CD pipeline and visualize reports with
 [CML](../tools.md).
 
-## Environment
-
-This guide has been written with :simple-apple: macOS and :simple-linux: Linux
-operating systems in mind. If you use :fontawesome-brands-windows: Windows, you
-might encounter issues. Please use the
-[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
-(WSL 2) for optimal results.
-
 ## Requirements
 
 The following requirements are necessary to follow this part in addition to

--- a/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
+++ b/docs/part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md
@@ -127,6 +127,17 @@ gcloud components install kubectl
 As per the instructions, you will need to install the `gke-gcloud-auth-plugin`
 authentication plugin as well.
 
+!!! tip "kubectl fails with a client-go credential plugin error?"
+
+    If `kubectl` fails with an error about a missing client-go credential plugin,
+    the `gke-gcloud-auth-plugin` is not installed. Install it with the following
+    command:
+
+    ```sh title="Execute the following command(s) in a terminal"
+    # Install the GKE authentication plugin
+    gcloud components install gke-gcloud-auth-plugin
+    ```
+
 ### Create the Kubernetes cluster
 
 In order to deploy the model on Kubernetes, you will need a Kubernetes cluster.

--- a/docs/part-3-serve-and-deploy/introduction.md
+++ b/docs/part-3-serve-and-deploy/introduction.md
@@ -12,18 +12,6 @@ Learn how to serve and deploy the model using
 [:simple-bentoml: BentoML](../tools.md) and
 [:simple-docker: Docker](../tools.md).
 
-## Environment
-
-This guide has been written with :simple-apple: macOS and :simple-linux: Linux
-operating systems in mind. If you use :fontawesome-brands-windows: Windows, you
-might encounter issues. Please use the
-[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
-(WSL 2) for optimal results.
-
-For this part, you also need to have
-[:simple-docker: Docker](https://www.docker.com/) installed. Docker will be
-utilized for setting up and managing the container registry.
-
 ## Requirements
 
 The following requirements are necessary to follow this part in addition to
@@ -33,7 +21,8 @@ those described in the
 - A [:simple-github: GitHub](https://github.com) account
 - A [:simple-googlecloud: Google Cloud](https://cloud.google.com) account
 - [:simple-docker: Docker](https://www.docker.com/) must be installed to set up
-  and manage the container registry
+  and manage the container registry (see the [Setup](../setup.md) page to install
+  it)
 
 ??? info "Using different platforms? Read this!"
 

--- a/docs/part-4-monitor-and-maintain/introduction.md
+++ b/docs/part-4-monitor-and-maintain/introduction.md
@@ -11,14 +11,6 @@ title: "Part 4 - Introduction"
 Learn how to monitor and maintain the model using
 [:simple-fluentbit: Fluent Bit](../tools.md) and [Evidently AI](../tools.md).
 
-## Environment
-
-This guide has been written with :simple-apple: macOS and :simple-linux: Linux
-operating systems in mind. If you use :fontawesome-brands-windows: Windows, you
-might encounter issues. Please use the
-[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
-(WSL 2) for optimal results.
-
 ## Requirements
 
 The following requirements are the same as those described in the

--- a/docs/part-5-label-data-and-retrain/introduction.md
+++ b/docs/part-5-label-data-and-retrain/introduction.md
@@ -11,14 +11,6 @@ title: "Part 5 - Introduction"
 Learn how to use the model to label new data using [Label Studio](../tools.md)
 and retrain the model iteratively.
 
-## Environment
-
-This guide has been written with :simple-apple: macOS and :simple-linux: Linux
-operating systems in mind. If you use :fontawesome-brands-windows: Windows, you
-might encounter issues. Please use the
-[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
-(WSL 2) for optimal results.
-
 ## Requirements
 
 The following requirements are necessary to follow this part in addition to

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,7 +28,7 @@ from the Microsoft Store for a modern terminal experience.
 
 From a PowerShell with administrator rights:
 
-```sh
+```powershell
 # Update WSL
 wsl --update
 
@@ -61,13 +61,19 @@ account has `sudo` rights inside the Linux environment.
 
 === ":simple-apple: macOS"
 
-    ```sh
-    # Install the available macOS updates
-    sudo softwareupdate --install --all
-    ```
+    !!! note
+
+        No specific macOS version is required for this guide. If you wish to update your
+        system, use **System Settings → General → Software Update**, keeping in mind
+        this can take a while.
 
     Install [Homebrew](https://brew.sh/) if it is not already installed. It is used
-    in the following sections.
+    in the following sections:
+
+    ```sh
+    # Install Homebrew
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    ```
 
 ## Python
 
@@ -91,7 +97,14 @@ The guide requires Python 3.13.
         [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):
 
         ```sh
+        # Install add-apt-repository if needed
+        sudo apt install software-properties-common
+
+        # Add the deadsnakes PPA and update the package lists
         sudo add-apt-repository ppa:deadsnakes/ppa -y
+        sudo apt update
+
+        # Install Python 3.13 and venv support
         sudo apt install python3.13 python3.13-venv
         ```
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,213 @@
+# Setup
+
+This page helps you prepare your machine before starting the guide, whether you
+use :fontawesome-brands-windows: Windows with
+[Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
+(WSL 2), a native :simple-linux: Linux (Ubuntu) installation or :simple-apple:
+macOS.
+
+!!! note
+
+    Unless stated otherwise, all commands on this page are meant to be run in your
+    terminal (the WSL terminal on Windows). Only the WSL 2 installation itself is
+    done from Windows PowerShell.
+
+## Windows only
+
+The following steps prepare a :fontawesome-brands-windows: Windows machine with
+WSL 2. Skip this section if you already use a native :simple-linux: Linux
+installation or :simple-apple: macOS.
+
+### Terminal
+
+Install
+[Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install)
+from the Microsoft Store for a modern terminal experience.
+
+### WSL 2
+
+From a PowerShell with administrator rights:
+
+```sh
+# Update WSL
+wsl --update
+
+# List the distributions available online
+wsl --list --online
+
+# Install Ubuntu (check the exact name in the list above, e.g. Ubuntu-26.04)
+wsl --install Ubuntu-26.04
+
+# Check the installed distributions and their WSL version
+wsl -l -v
+```
+
+On the first launch, Ubuntu asks you to create a username and password. This
+account has `sudo` rights inside the Linux environment.
+
+## System update
+
+=== ":simple-linux: :simple-ubuntu: Linux (Ubuntu)"
+
+    Inside the Linux terminal:
+
+    ```sh
+    # Update the package lists
+    sudo apt update
+
+    # Upgrade the installed packages
+    sudo apt upgrade
+    ```
+
+=== ":simple-apple: macOS"
+
+    ```sh
+    # Install the available macOS updates
+    sudo softwareupdate --install --all
+    ```
+
+    Install [Homebrew](https://brew.sh/) if it is not already installed. It is used
+    in the following sections.
+
+## Python
+
+The guide requires Python 3.13.
+
+=== ":simple-linux: :simple-ubuntu: Linux (Ubuntu)"
+
+    Install Python 3.13 with the package manager, and `unzip` which is used in the
+    guide to extract archives:
+
+    ```sh
+    # Install Python 3.13, venv support and unzip
+    sudo apt install python3.13 python3.13-venv unzip
+    ```
+
+    !!! tip "Why Python 3.13?"
+
+        Recent Ubuntu releases ship a newer Python version (3.14) by default, but this
+        guide explicitly requires Python 3.13 for framework compatibility. If
+        `python3.13` is not packaged for your Ubuntu release, use the
+        [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):
+
+        ```sh
+        sudo add-apt-repository ppa:deadsnakes/ppa -y
+        sudo apt install python3.13 python3.13-venv
+        ```
+
+=== ":simple-apple: macOS"
+
+    ```sh
+    # Install Python 3.13
+    brew install python@3.13
+    ```
+
+    `unzip`, used in the guide to extract archives, is already included with macOS.
+
+=== ":simple-linux: :simple-apple: Using uv"
+
+    Install [:simple-uv: uv](https://docs.astral.sh/uv/), which can also install and
+    manage Python versions by itself:
+
+    ```sh
+    # Install uv
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Make uv available in the current shell
+    source $HOME/.local/bin/env
+    ```
+
+    Python 3.13 is then installed automatically when creating a virtual environment
+    with `uv venv --python 3.13`.
+
+## Git
+
+=== ":simple-linux: :simple-ubuntu: Linux (Ubuntu)"
+
+    ```sh
+    # Install Git
+    sudo apt install git
+    ```
+
+=== ":simple-apple: macOS"
+
+    ```sh
+    # Install Git
+    brew install git
+    ```
+
+Then configure your identity:
+
+```sh
+# Configure your identity (replace with your own information)
+git config --global user.email "your@email"
+git config --global user.name "Your Name"
+
+# Configure line endings
+git config --global core.autocrlf input
+```
+
+!!! tip "For WSL 2 users"
+
+    On native Windows, Git is usually configured with `core.autocrlf true` to
+    convert line endings between Windows files (CRLF) and the repository (LF).
+    Inside WSL, Git is a Linux program with its own configuration, and files are
+    checked out and used by Linux tools, so `input` is the correct setting there.
+
+## Docker
+
+Docker is used later in the guide to package and serve the model.
+
+=== ":fontawesome-brands-windows: :simple-apple: :simple-linux: Using Docker Desktop"
+
+    Install [Docker Desktop](https://www.docker.com/products/docker-desktop/),
+    available for :fontawesome-brands-windows: Windows, :simple-apple: macOS and
+    :simple-linux: Linux.
+
+    On Windows, Docker Desktop uses the WSL 2 backend and integrates with your
+    Ubuntu distribution. Make sure the integration is enabled in
+    **Settings → Resources → WSL Integration**.
+
+=== ":simple-ubuntu: Using Docker CLI (Linux only)"
+
+    On :simple-linux: Linux, install the Docker engine and CLI directly in the Linux
+    environment:
+
+    ```sh
+    # Install Docker and the Buildx plugin
+    sudo apt install docker.io docker-buildx
+
+    # Check that the Docker service is running
+    sudo systemctl status docker
+
+    # Add your user to the docker group (created automatically by the package)
+    sudo usermod -aG docker $USER
+    ```
+
+    Log out and back in (or run `su - $USER` to start a fresh shell), then check
+    with `groups` that `docker` appears in the list.
+
+    !!! tip "For WSL 2 users"
+
+        If `systemctl` reports that systemd is not running, start the Docker service
+        manually with `sudo service docker start`.
+
+## Kubernetes tools
+
+The deployment chapters require `kubectl` and the `gke-gcloud-auth-plugin`
+authentication plugin. Both are installed later in the guide with the
+[Google Cloud CLI](./part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md):
+
+```sh
+# Install kubectl and the GKE authentication plugin with gcloud
+gcloud components install kubectl gke-gcloud-auth-plugin
+```
+
+If `kubectl` fails with an error about a missing client-go credential plugin,
+the `gke-gcloud-auth-plugin` is not installed. Alternatively, on Ubuntu both are
+available as packages once the Google Cloud apt repository is configured:
+
+```sh
+# Install the GKE authentication plugin with apt
+sudo apt install kubectl google-cloud-cli-gke-gcloud-auth-plugin
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -63,7 +63,8 @@ account has `sudo` rights inside the Linux environment.
 
 ## Python
 
-The guide requires Python 3.13.
+The guide requires Python 3.13 for framework compatibility, even though recent
+systems ship a newer version by default.
 
 === ":simple-linux: :simple-ubuntu: Linux (Ubuntu)"
 
@@ -75,11 +76,9 @@ The guide requires Python 3.13.
     sudo apt install python3.13 python3.13-venv unzip
     ```
 
-    !!! tip "Why Python 3.13?"
+    !!! tip "Python 3.13 not available?"
 
-        Recent Ubuntu releases ship a newer Python version (3.14) by default, but this
-        guide explicitly requires Python 3.13 for framework compatibility. If
-        `python3.13` is not packaged for your Ubuntu release, use the
+        If `python3.13` is not packaged for your Ubuntu release, use the
         [deadsnakes PPA](https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa):
 
         ```sh
@@ -165,9 +164,11 @@ Docker is used later in the guide to package and serve the model.
 
     Then check the following settings:
 
-    - :fontawesome-brands-windows: **Windows**: make sure the WSL integration is
-      enabled in **Settings → Resources → WSL Integration** so Docker Desktop
-      integrates with your Ubuntu distribution.
+    - :fontawesome-brands-windows: **Windows (including WSL 2)**: install the
+      Windows version of Docker Desktop, not the Linux version inside WSL. Then make
+      sure the WSL integration is enabled in
+      **Settings → Resources → WSL Integration** so Docker Desktop integrates with
+      your Ubuntu distribution.
     - :simple-apple: **macOS**: in case of troubles when building Docker images
       on Apple Silicon, consider disabling
       **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -145,7 +145,7 @@ git config --global user.name "Your Name"
 git config --global core.autocrlf input
 ```
 
-!!! tip "For WSL 2 users"
+??? tip "For WSL 2 users"
 
     On native Windows, Git is usually configured with `core.autocrlf true` to
     convert line endings between Windows files (CRLF) and the repository (LF).

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -154,8 +154,6 @@ git config --global core.autocrlf input
 
 ## Docker
 
-Docker is used later in the guide to package and serve the model.
-
 === ":fontawesome-brands-windows: :simple-apple: :simple-linux: Using Docker Desktop"
 
     Install [Docker Desktop](https://www.docker.com/products/docker-desktop/),

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -138,7 +138,7 @@ Then configure your identity:
 
 ```sh
 # Configure your identity (replace with your own information)
-git config --global user.email "your@email"
+git config --global user.email "your.email@example.com"
 git config --global user.name "Your Name"
 
 # Configure line endings

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,8 +12,6 @@ The following steps prepare a :fontawesome-brands-windows: Windows machine with
 WSL 2. Skip this section if you already use a native :simple-linux: Linux
 installation or :simple-apple: macOS.
 
-### WSL 2
-
 From a PowerShell with administrator rights:
 
 ```powershell

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -175,10 +175,10 @@ Docker is used later in the guide to package and serve the model.
       **Settings → General**. The guide builds Docker images for the `linux/amd64`
       architecture, and the build can fail under Rosetta emulation.
 
-=== ":simple-ubuntu: Using Docker CLI (Linux only)"
+=== ":simple-linux: :simple-ubuntu: Using Docker CLI"
 
     On :simple-linux: Linux, install the Docker engine and CLI directly in the Linux
-    environment:
+    environment, without the Docker Desktop client:
 
     ```sh
     # Install Docker and the Buildx plugin

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -6,23 +6,11 @@ use :fontawesome-brands-windows: Windows with
 (WSL 2), a native :simple-linux: Linux (Ubuntu) installation or :simple-apple:
 macOS.
 
-!!! note
-
-    Unless stated otherwise, all commands on this page are meant to be run in your
-    terminal (the WSL terminal on Windows). Only the WSL 2 installation itself is
-    done from Windows PowerShell.
-
 ## Windows only
 
 The following steps prepare a :fontawesome-brands-windows: Windows machine with
 WSL 2. Skip this section if you already use a native :simple-linux: Linux
 installation or :simple-apple: macOS.
-
-### Terminal
-
-Install
-[Windows Terminal](https://learn.microsoft.com/en-us/windows/terminal/install)
-from the Microsoft Store for a modern terminal experience.
 
 ### WSL 2
 
@@ -204,23 +192,3 @@ Docker is used later in the guide to package and serve the model.
 
         If `systemctl` reports that systemd is not running, start the Docker service
         manually with `sudo service docker start`.
-
-## Kubernetes tools
-
-The deployment chapters require `kubectl` and the `gke-gcloud-auth-plugin`
-authentication plugin. Both are installed later in the guide with the
-[Google Cloud CLI](./part-3-serve-and-deploy/chapter-35-deploy-and-access-the-model-on-kubernetes.md):
-
-```sh
-# Install kubectl and the GKE authentication plugin with gcloud
-gcloud components install kubectl gke-gcloud-auth-plugin
-```
-
-If `kubectl` fails with an error about a missing client-go credential plugin,
-the `gke-gcloud-auth-plugin` is not installed. Alternatively, on Ubuntu both are
-available as packages once the Google Cloud apt repository is configured:
-
-```sh
-# Install the GKE authentication plugin with apt
-sudo apt install kubectl google-cloud-cli-gke-gcloud-auth-plugin
-```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -105,8 +105,8 @@ The guide requires Python 3.13.
 
 === ":simple-linux: :simple-apple: Using uv"
 
-    Install [:simple-uv: uv](https://docs.astral.sh/uv/), which can also install and
-    manage Python versions by itself:
+    Alternatively to the system package manager, install
+    [:simple-uv: uv](https://docs.astral.sh/uv/) and use it to install Python 3.13:
 
     ```sh
     # Install uv
@@ -114,10 +114,10 @@ The guide requires Python 3.13.
 
     # Make uv available in the current shell
     source $HOME/.local/bin/env
-    ```
 
-    Python 3.13 is then installed automatically when creating a virtual environment
-    with `uv venv --python 3.13`.
+    # Install Python 3.13
+    uv python install 3.13
+    ```
 
 ## Git
 
@@ -163,9 +163,16 @@ Docker is used later in the guide to package and serve the model.
     available for :fontawesome-brands-windows: Windows, :simple-apple: macOS and
     :simple-linux: Linux.
 
-    On Windows, Docker Desktop uses the WSL 2 backend and integrates with your
-    Ubuntu distribution. Make sure the integration is enabled in
-    **Settings → Resources → WSL Integration**.
+    Then check the following settings:
+
+    - :fontawesome-brands-windows: **Windows**: make sure the WSL integration is
+      enabled in **Settings → Resources → WSL Integration** so Docker Desktop
+      integrates with your Ubuntu distribution.
+    - :simple-apple: **macOS**: in case of troubles when building Docker images
+      on Apple Silicon, consider disabling
+      **Use Rosetta for x86_64/amd64 emulation on Apple Silicon** in
+      **Settings → General**. The guide builds Docker images for the `linux/amd64`
+      architecture, and the build can fail under Rosetta emulation.
 
 === ":simple-ubuntu: Using Docker CLI (Linux only)"
 

--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -13,7 +13,8 @@ The five parts are:
 
 - Introduction - Learn about the [concept](./concept.md) behind MLOps, the
   [philosophy](./philosophy.md), and the [tools](./tools.md) used throughout, then
-  [set up](./setup.md) your machine.
+  [set up](./setup.md) your machine. A [cheatsheet](./cheatsheet.md) of useful
+  terminal commands is available throughout the guide.
 - [Part 1 - Local training and evaluation](./part-1-local-training-and-evaluation/introduction.md) -
   Learn how to train a model locally and evaluate it using DVC.
     - [Chapter 1.1 - Run a simple ML experiment with Jupyter Notebook](./part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md)

--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -12,7 +12,7 @@ retrainable system.
 The five parts are:
 
 - Introduction - Learn about the [concept](./concept.md) behind MLOps, the
-  [philosophy](./philosophy.md), and the [tools](./tools.md) used throughout, and
+  [philosophy](./philosophy.md), and the [tools](./tools.md) used throughout, then
   [set up](./setup.md) your machine.
 - [Part 1 - Local training and evaluation](./part-1-local-training-and-evaluation/introduction.md) -
   Learn how to train a model locally and evaluate it using DVC.

--- a/docs/syllabus.md
+++ b/docs/syllabus.md
@@ -12,7 +12,8 @@ retrainable system.
 The five parts are:
 
 - Introduction - Learn about the [concept](./concept.md) behind MLOps, the
-  [philosophy](./philosophy.md), and the [tools](./tools.md) used throughout.
+  [philosophy](./philosophy.md), and the [tools](./tools.md) used throughout, and
+  [set up](./setup.md) your machine.
 - [Part 1 - Local training and evaluation](./part-1-local-training-and-evaluation/introduction.md) -
   Learn how to train a model locally and evaluate it using DVC.
     - [Chapter 1.1 - Run a simple ML experiment with Jupyter Notebook](./part-1-local-training-and-evaluation/chapter-11-run-a-simple-ml-experiment-with-jupyter-notebook.md)

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,6 +54,7 @@ nav = [
       { "Concept" = "concept.md" },
       { "Philosophy" = "philosophy.md" },
       { "Tools" = "tools.md" },
+      { "Setup" = "setup.md" },
       { "References" = "references.md" },
       { "Cheatsheet" = "cheatsheet.md" },
     ] },

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,8 +55,8 @@ nav = [
       { "Philosophy" = "philosophy.md" },
       { "Tools" = "tools.md" },
       { "Setup" = "setup.md" },
-      { "References" = "references.md" },
       { "Cheatsheet" = "cheatsheet.md" },
+      { "References" = "references.md" },
     ] },
   { "🧪 Local training and evaluation" = [
       { "Introduction" = "part-1-local-training-and-evaluation/introduction.md" },


### PR DESCRIPTION
## Summary

- Add a new **Setup** page in the Introduction section with condensed, tab-based instructions to prepare a machine before starting the guide:
  - Windows only: WSL 2 installation
  - System update, Python 3.13 (apt / Homebrew / uv), Git configuration and Docker (Desktop or CLI)
- Use per-OS content tabs (`Linux (Ubuntu)` / `macOS`) that stay in sync across sections, with icons indicating the supported platforms for each tool
- Link the page from the syllabus and the Part 1 introduction so readers hit it before Chapter 1.1
- Remove the duplicated Environment sections from the part 2 to 5 introductions, now covered by the setup page
- Update `AGENTS.md` repository structure accordingly

## Validation

- `mdwrap --check docs presentation` passes
- `zensical build --clean` completes with no issues